### PR TITLE
backslashes dont work on linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "start": "node .\\dist\\main.js "
+    "start": "node ./dist/main.js"
   },
   "devDependencies": {
     "@types/eris-sharder": "^1.10.1",


### PR DESCRIPTION
`node` on unix-like systems try to access a file called "`.distmain.js`" because the package.json uses backslashes as path seperators
```
zulc22@zulcserv ~/vcping (git)-[master] % npm run start

> start
> node .\dist\main.js

node:internal/modules/cjs/loader:1093
  throw err;
  ^

Error: Cannot find module '/home/zulc22/vcping/.distmain.js'
    at Module._resolveFilename (node:internal/modules/cjs/loader:1090:15)
    at Module._load (node:internal/modules/cjs/loader:934:27)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:83:12)
    at node:internal/main/run_main_module:23:47 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}

Node.js v19.9.0
```